### PR TITLE
Make test conform to rakudo/rakudo#4096

### DIFF
--- a/t/06-arrays.rakutest
+++ b/t/06-arrays.rakutest
@@ -95,7 +95,7 @@ subtest {
     temp %*ENV = ( :INTA<1>, :INTB<2>, :INTC<3> );
 
     my $tc = TypeTest.new();
-    is-deeply $tc.int, Array[Int].new(1,2,3), "We have an array";
+    is-deeply $tc.int, Array[Int].new(<1 2 3>), "We have an array";
 
 }, "Int Typed";
 


### PR DESCRIPTION
The PR rakudo/rakudo#4096 changes the way explicit coercions like
`Int("42")` work. They now utilize the standard coercion protocol meaning
that where earlier `Int(IntStr.new)` was resulting in `Int`, it is now
results in no coercion performed because `IntStr` subclasses `Int`.